### PR TITLE
GH-25: upgrade poi to 5.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -26,7 +26,7 @@
 	<description>Read from Excel files to POJO's really fast!</description>
 
     <properties>
-        <poi.version>5.0.0</poi.version>
+        <poi.version>5.1.0</poi.version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <developers>


### PR DESCRIPTION
Previous poi versions don't support Java 9+ modules, so when it comes to compilation in such projects, it fails. This update doesn't affect anything except the actual opportunity to use this library in modular applications.

Relates to https://github.com/sskorol/test-data-supplier/issues/105

Closes #25